### PR TITLE
fix(ci): add Node.js to CI image for GitHub Actions

### DIFF
--- a/.github/images/ci/Dockerfile
+++ b/.github/images/ci/Dockerfile
@@ -4,6 +4,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     libpq-dev \
     gcc \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js (required for GitHub Actions)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /deps


### PR DESCRIPTION
## Summary
- Added Node.js 22 to the CI container image
- Required because GitHub Actions uses Node.js to run JavaScript-based actions like `actions/checkout`

## Test plan
- [ ] CI image builds successfully
- [ ] CI workflow runs with the updated image