### PR TITLE
ci: add autofix workflow for bot PRs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,52 @@
+name: Autofix
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install formatters
+        run: pip install black isort
+
+      - name: Run formatters
+        run: |
+          black bot/ config/ database/ main.py
+          isort bot/ config/ database/ main.py
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: auto-format code with black and isort"
+          git push


### PR DESCRIPTION
## Summary

Adds an autofix workflow that automatically formats code when Renovate or Dependabot creates PRs.

## What it does

- Triggers on PRs from `renovate[bot]` or `dependabot[bot]`
- Runs `black` and `isort` to format Python code
- Commits and pushes the changes back to the PR branch

## Why

Renovate PRs that update dependencies (like `requirements.txt`) sometimes need code reformatting to pass CI. This automates that process so the PRs can auto-merge without manual intervention.