### PR TITLE
feat: run database migrations on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ COPY --chown=discord:discord database/ ./database/
 COPY --chown=discord:discord config/ ./config/
 COPY --chown=discord:discord main.py .
 COPY --chown=discord:discord alembic.ini .
+COPY --chown=discord:discord entrypoint.sh .
 
 # Switch to non-root user
 USER discord
@@ -64,6 +65,6 @@ EXPOSE 8080 8443
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
   CMD curl -f http://localhost:8080/healthz || exit 1
 
-# Run application
-CMD ["python", "main.py"]
+# Run application with migrations
+ENTRYPOINT ["./entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+echo "Running database migrations..."
+alembic upgrade head
+echo "Migrations complete"
+
+echo "Starting bot..."
+exec python main.py


### PR DESCRIPTION
## Summary
- Add entrypoint script that runs `alembic upgrade head` before starting the bot
- Ensures database schema is always up to date on container start
- Works regardless of deployment method (K8s, Docker Compose, etc.)

## Test plan
- [x] Build image locally and verify migrations run on startup
- [x] Deploy to cluster and confirm bot starts successfully