### PR TITLE
fix(docker): set execute permission on entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY --chown=discord:discord config/ ./config/
 COPY --chown=discord:discord main.py .
 COPY --chown=discord:discord alembic.ini .
 COPY --chown=discord:discord entrypoint.sh .
+RUN chmod +x entrypoint.sh
 
 # Switch to non-root user
 USER discord

--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ echo "✓ Docker image built successfully"
 # Smoke test - verify container starts and can import modules
 echo ""
 echo "Running container smoke test..."
-docker run --rm ffobot:test python -c "
+docker run --rm --entrypoint python ffobot:test -c "
 import bot
 import config
 import database


### PR DESCRIPTION
- Add chmod +x in Dockerfile to ensure entrypoint is executable
- Update build.sh smoke test to override entrypoint for import tests