### PR TITLE
fix: remove loop.stop() to prevent event loop stopped before future completed

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,6 @@ class GracefulShutdown:
             await self.bot.close()
         except Exception as e:
             logger.error(f"Shutdown error: {e}", exc_info=True)
-        asyncio.get_event_loop().stop()
 
 
 async def main():


### PR DESCRIPTION
Fixes the 'Event loop stopped before Future completed' error during SIGTERM shutdown. Calling loop.stop() after bot.close() was stopping the event loop before Discord and other async tasks could finish cleanup.